### PR TITLE
talk一覧取得用APIを追加する上でschemaを更新

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -86,7 +86,7 @@ paths:
           description: Invalid params supplied
         '404':
           description: Track not found
-  /api/v1/events/{eventId}/talks:
+  /api/v1/talks:
     get:
       tags:
         - Talk
@@ -214,7 +214,7 @@ components:
         id:
           type: number
         trackId:
-          type: string
+          type: number
         videoPlatform:
           type: string
         videoId:


### PR DESCRIPTION
- talk一覧を取得する際のパスにイベントIDは不要（パラメータで渡すため）
- trackIdはnumber

api追加: https://github.com/cloudnativedaysjp/dreamkast/pull/408