### PR TITLE
TrackIDを指定したTalk取得をQueryを利用する形式に変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+## mockファイル群をディレクトリごと削除
+remove_mock:
+	rm -rf mock/*
+
+## ymlからmockを生成
+build_mock:
+	$(MAKE) remove_mock
+	docker run -u 1000:1000 --rm -v `pwd`:/work swaggerapi/swagger-codegen-cli-v3 generate -l nodejs-server -i /work/swagger.yml -o /work/mock
+
+## mockServerを起動
+api_mock_run:
+	$(MAKE) build_mock
+	cd ./mock && npm start

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ docker run -u 1000:1000 --rm -v `pwd`:/work swaggerapi/swagger-codegen-cli-v3 ge
 npm start
 ```
 
+or
+
+```
+make api_mock_run
+```
+
 To view the Swagger UI interface:
 
 ```

--- a/swagger.yml
+++ b/swagger.yml
@@ -91,6 +91,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: trackId
+          in: query
+          description: ID of track
+          required: false
+          schema:
+            type: string
       responses:
         '200':
           description: OK
@@ -122,30 +128,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Talk'
-        '400':
-          description: Invalid params supplied
-        '404':
-          description: Talk not found
-  /api/v1/talks/{trackId}:
-    get:
-      tags:
-        - Talk
-      parameters:
-        - name: trackId
-          in: path
-          description: ID of track
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Talk'
         '400':
           description: Invalid params supplied
         '404':


### PR DESCRIPTION
ref: https://github.com/cloudnativedaysjp/dreamkast-api-docs/pull/10#issuecomment-775588602

* TrackIDを指定したTalk取得をQueryを利用する形式に変更
* MockServer関連のMakefileを作成
* READMEにその旨を記載