### PR TITLE
speakersはidと名前両方ほしい

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -303,7 +303,12 @@ components:
           description: array of speakers name
           type: array
           items:
-            type: string
+            type: object
+            properties:
+              id:
+                type: number
+              name:
+                type: string
         dayId:
           type: number
         showOnTimetable:


### PR DESCRIPTION
登壇者のチャットメッセージを強調表示するためにIDが必要なので変更します

https://github.com/cloudnativedaysjp/dreamkast-ui/issues/76