### PR TITLE
add test: GET /api/v1/chat_messages

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -215,6 +215,7 @@ paths:
           content:
             application/json:
               schema:
+                type: array
                 items:
                   $ref: '#/components/schemas/ChatMessage'
         '400':
@@ -528,7 +529,7 @@ components:
         - $ref: '#/components/schemas/ChatMessageProperties'
       required:
         - eventAbbr
-        - talkId
+        - roomId
         - body
         - messageType
       example:
@@ -552,6 +553,7 @@ components:
           type: number
         speakerId:
           type: number
+          nullable: true
         eventAbbr:
           type: string
         roomId:
@@ -565,6 +567,9 @@ components:
         messageType:
           type: string
           enum: [chat, qa]
+        replyTo:
+          type: number
+          nullable: true
     Sponsor:
       type: object
       additionalProperties: false


### PR DESCRIPTION
テスト追加時に気づいた変更点を判定

- GET /api/v1/chat_messages のレスポンスボディはChatMessage
- Objectの配列なので、swaggerでも配列を明示する必要があった
- requiedの talkId は間違いで roomId が正しい
- speakerId と replyTo にはnullが入る可能性があるのでnullableにする

ref: https://github.com/cloudnativedaysjp/dreamkast/pull/1012